### PR TITLE
add name attribute to js file

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -3,22 +3,22 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-powermanagement"
     version="1.0.1">
-	
+
     <name>Cordova PowerManagement plugin</name>
     <description>full wake lock for the app which runs for a long time without user interaction.</description>
-    <author>Sang Ki Kwon (Cranberrygame)</author>		
+    <author>Sang Ki Kwon (Cranberrygame)</author>
     <license>MIT</license>
     <keywords>cordova,power management</keywords>
     <repo>https://github.com/cranberrygame/cordova-plugin-powermanagement</repo>
-    <issue>https://github.com/cranberrygame/cordova-plugin-ad-powermanagement/issues</issue> 	
+    <issue>https://github.com/cranberrygame/cordova-plugin-ad-powermanagement/issues</issue>
 	<engines>
 	    <engine name="cordova" version=">=3.0.0" />
 	</engines>
-	
-    <js-module src="www/powermanagement.js">
+
+    <js-module src="www/powermanagement.js" name="PowerManagement">
         <clobbers target="window.powermanagement" />
     </js-module>
-	
+
 	<!-- android -->
 	<platform name="android">
 		<config-file target="res/xml/config.xml" parent="/*">
@@ -29,7 +29,7 @@
 
 		<source-file src="src/android/com/simplec/phonegap/plugins/powermanagement/PowerManagement.java" target-dir="src/com/simplec/phonegap/plugins/powermanagement"/>
 	</platform>
-	  
+
 	<!-- ios -->
 	<platform name="ios">
 
@@ -40,7 +40,7 @@
 		</config-file>
 
 		<header-file src="src/ios/PowerManagement.h" />
-		<source-file src="src/ios/PowerManagement.m" />		
+		<source-file src="src/ios/PowerManagement.m" />
 	</platform>
 
 </plugin>


### PR DESCRIPTION
missing name attribute in plugin xml causes an error in newer cordova versions, this fixes it
